### PR TITLE
feat: tag-based listing in purge command

### DIFF
--- a/internal/worker/purger.go
+++ b/internal/worker/purger.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/Azure/acr-cli/acr"
+	"github.com/Azure/acr-cli/cmd/common"
 	"github.com/Azure/acr-cli/internal/api"
 	"github.com/alitto/pond/v2"
 )
@@ -62,32 +63,87 @@ func (p *Purger) PurgeTags(ctx context.Context, tags []acr.TagAttributesBase) (i
 	return int(deletedTags.Load()), err
 }
 
+// deleteManifest handles the deletion of a single manifest with proper error handling and logging
+func (p *Purger) deleteManifest(ctx context.Context, manifestDigest string, deletedCount *atomic.Int64) error {
+	resp, err := p.acrClient.DeleteManifest(ctx, p.repoName, manifestDigest)
+	if err == nil {
+		fmt.Printf("Deleted %s/%s@%s\n", p.loginURL, p.repoName, manifestDigest)
+		deletedCount.Add(1)
+		return nil
+	}
+
+	if resp != nil && resp.Response != nil && resp.StatusCode == http.StatusNotFound {
+		// If the manifest is not found it can be assumed to have been deleted.
+		deletedCount.Add(1)
+		fmt.Printf("Skipped %s/%s@%s, HTTP status: %d\n", p.loginURL, p.repoName, manifestDigest, resp.StatusCode)
+		return nil
+	}
+
+	fmt.Printf("Failed to delete %s/%s@%s, error: %v\n", p.loginURL, p.repoName, manifestDigest, err)
+	return err
+}
+
 // PurgeManifests purges a list of manifests concurrently, and returns a count of deleted manifests and the first error occurred.
 func (p *Purger) PurgeManifests(ctx context.Context, manifests []string) (int, error) {
 	var deletedManifests atomic.Int64 // Count of successfully deleted tags
 	group := p.pool.NewGroup()
 	for _, manifest := range manifests {
 		group.SubmitErr(func() error {
-			resp, err := p.acrClient.DeleteManifest(ctx, p.repoName, manifest)
-			if err == nil {
-				fmt.Printf("Deleted %s/%s:%s\n", p.loginURL, p.repoName, manifest)
-				// Increment the count of successfully deleted tags atomically
-				deletedManifests.Add(1)
-				return nil
-			}
-
-			if resp != nil && resp.Response != nil && resp.StatusCode == http.StatusNotFound {
-				// If the tag is not found it can be assumed to have been deleted.
-				deletedManifests.Add(1)
-				fmt.Printf("Skipped %s/%s:%s, HTTP status: %d\n", p.loginURL, p.repoName, manifest, resp.StatusCode)
-				return nil
-			}
-
-			fmt.Printf("Failed to delete %s/%s:%s, error: %v\n", p.loginURL, p.repoName, manifest, err)
-			return err
-
+			return p.deleteManifest(ctx, manifest, &deletedManifests)
 		})
 	}
+	err := group.Wait()
+	return int(deletedManifests.Load()), err
+}
+
+// PurgeUntaggedManifests gets all manifests from the repository, excludes tag-related ones, and purges the remaining manifests.
+// The tagRelatedManifests map contains manifest digests that should be skipped (e.g., tagged manifests and their dependencies).
+func (p *Purger) PurgeUntaggedManifests(ctx context.Context, toSkipManifests map[string]struct{}) (int, error) {
+	var deletedManifests atomic.Int64
+	group := p.pool.NewGroup()
+	lastManifestDigest := ""
+
+	// Get all manifests from the repository and delete untagged ones directly
+	for {
+		resultManifests, err := p.acrClient.GetAcrManifests(ctx, p.repoName, "", lastManifestDigest)
+		if err != nil {
+			if resultManifests != nil && resultManifests.Response.Response != nil && resultManifests.StatusCode == http.StatusNotFound {
+				// Repository not found, return 0 deleted
+				return 0, nil
+			}
+			return 0, err
+		}
+
+		if resultManifests == nil || resultManifests.ManifestsAttributes == nil || len(*resultManifests.ManifestsAttributes) == 0 {
+			break
+		}
+
+		manifests := *resultManifests.ManifestsAttributes
+		for _, manifest := range manifests {
+			if manifest.Digest == nil || !common.IsManifestDeletable(manifest) {
+				continue
+			}
+
+			// Skip manifests that are in the tag-related set
+			if _, ok := toSkipManifests[*manifest.Digest]; ok {
+				continue
+			}
+
+			// Delete the manifest directly using goroutines
+			manifestDigest := *manifest.Digest // Capture for closure
+			group.SubmitErr(func() error {
+				return p.deleteManifest(ctx, manifestDigest, &deletedManifests)
+			})
+		}
+
+		// Get the last manifest digest for pagination
+		if len(manifests) == 0 {
+			break
+		}
+		lastManifestDigest = *manifests[len(manifests)-1].Digest
+	}
+
+	// Wait for all deletion tasks to complete
 	err := group.Wait()
 	return int(deletedManifests.Load()), err
 }


### PR DESCRIPTION
This pull request adds a new `--list-via-tag` flag to the `purge` command, enabling tag-based listing for purge operations.

Instead of scanning and deleting only untagged manifests, this flag scans all manifests associated with existing tags and skips their deletion. When most manifests are untagged, this approach significantly reduces the overall time required for the purge operation.
